### PR TITLE
Make EmptyResultSet support python 2 iterators

### DIFF
--- a/pyes/es.py
+++ b/pyes/es.py
@@ -1706,6 +1706,9 @@ class EmptyResultSet(object):
     def __next__(self):
         raise StopIteration
 
+    if six.PY2:
+        next = __next__
+
     def __iter__(self):
         return self
 


### PR DESCRIPTION
All other iterator classes in this module uses this python 2 fix.

If a regression test is expected, please point me in the right direction on how where to put it. I don't feel like understanding too much of the setup right now.